### PR TITLE
fix status bar issue & race condition

### DIFF
--- a/Phunware/MRAID/MRAIDHandler.swift
+++ b/Phunware/MRAID/MRAIDHandler.swift
@@ -262,6 +262,10 @@ public class MRAIDHandler : NSObject, WKUIDelegate, WKNavigationDelegate {
         
     }
     
+    public func getExpandProperties() -> ExpandProperties? {
+        return expandProperties;
+    }
+    
     /** ------------------------------------------------------------------------
      Invoke MRAID js functions
      ------------------------------------------------------------------------ */
@@ -365,9 +369,13 @@ public class MRAIDHandler : NSObject, WKUIDelegate, WKNavigationDelegate {
             if(expandProperties?.useCustomClose != true){
                 addCloseButton(to:activeWebView, action:#selector(onCloseExpandedClicked), showButton:expandProperties?.useCustomClose ?? true)
             }
-            setMRAIDState(States.EXPANDED)
-            setMRAIDCurrentPosition(parentVC!.view.frame)
-            setMRAIDSizeChanged(to:parentVC!.view.frame.size);
+            // give the webview a little bit of time to resize before informing the ad of the change
+            // to avoid some potential bugs
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.025) { // change 2 to desired number of seconds
+                self.setMRAIDCurrentPosition(self.parentVC!.view.frame)
+                self.setMRAIDSizeChanged(to:self.parentVC!.view.frame.size);
+                self.setMRAIDState(States.EXPANDED)
+            }
         }
     }
     
@@ -459,9 +467,15 @@ public class MRAIDHandler : NSObject, WKUIDelegate, WKNavigationDelegate {
             }
             mraidDelegate!.resize(to:resizeProperties!)
             addCloseButton(to:activeWebView, action:#selector(onCloseResizeClicked), showButton:false, position:resizeProperties?.customClosePosition ?? "top-right")
-            setMRAIDSizeChanged(to:CGSize(width:resizeProperties!.width!, height:resizeProperties!.height!))
+            // give the webview a little bit of time to resize before informing the ad of the change
+            // to avoid some potential bugs
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.025) { // change 2 to desired number of seconds
+                self.setMRAIDSizeChanged(to:CGSize(width:self.resizeProperties!.width!, height:self.resizeProperties!.height!))
+                self.setMRAIDState(States.RESIZED)
+            }
+        }else {
+            setMRAIDState(States.RESIZED)
         }
-        setMRAIDState(States.RESIZED)
     }
     
     private func setOrientationProperties(_ args:String?){

--- a/Phunware/MRAID/PWMRAIDBanner.swift
+++ b/Phunware/MRAID/PWMRAIDBanner.swift
@@ -66,6 +66,12 @@ public class PWMRAIDBanner: UIViewController, MRAIDDelegate {
         initWebView()
     }
     
+    public override var prefersStatusBarHidden: Bool {
+        get {
+            return true
+        }
+    }
+    
     private func initWebView(){
         mraidHandler = MRAIDHandler()
         mraidHandler.respectsSafeArea = respectSafeArea
@@ -168,7 +174,7 @@ public class PWMRAIDBanner: UIViewController, MRAIDDelegate {
             if(mraidHandler.respectsSafeArea){
                 if #available(iOS 11.0, *) {
                     let guide = parentController.view.safeAreaLayoutGuide
-                    NSLayoutConstraint.activate([view.bottomAnchor.constraintEqualToSystemSpacingBelow(guide.bottomAnchor, multiplier: 1.0)])
+                    NSLayoutConstraint.activate([view.bottomAnchor.constraint(equalTo: guide.bottomAnchor, constant: 0)])
                 } else {
                     NSLayoutConstraint.activate([view.bottomAnchor.constraint(equalTo: parentController.bottomLayoutGuide.topAnchor, constant: standardSpacing)])
                 }
@@ -320,8 +326,9 @@ public class PWMRAIDBanner: UIViewController, MRAIDDelegate {
         view.frame = CGRect(x:0, y:0, width:UIScreen.main.bounds.width, height:UIScreen.main.bounds.height)
         view.removeConstraints(view.constraints)
         setInitialConstraints()
-        mraidHandler.setCurrentPosition(view.frame)
-        mraidHandler.setMRAIDSizeChanged(to: fullScreenSize)
+        // handled in mraidHandler
+//        mraidHandler.setCurrentPosition(view.frame)
+//        mraidHandler.setMRAIDSizeChanged(to: fullScreenSize)
     }
     
     //  ---------------------------------------

--- a/Phunware/MRAID/PWMRAIDInterstitial.swift
+++ b/Phunware/MRAID/PWMRAIDInterstitial.swift
@@ -144,13 +144,15 @@ public class PWMRAIDInterstitial : UIViewController, MRAIDDelegate {
         
         let closeButton = UIButton(frame:buttonRect)
         closeButton.translatesAutoresizingMaskIntoConstraints = false
- 
         
-        closeButton.setTitleColor(UIColor.white, for:UIControlState.normal)
-        closeButton.setBackgroundImage(UIImage(named:"closeButtonBG", in: Bundle(identifier:"phunware.ios.mraid.sdk"), compatibleWith:nil), for: UIControlState.normal)
-        closeButton.setTitle("X", for:UIControlState.normal)
-        closeButton.titleLabel!.textAlignment = NSTextAlignment.center
-        closeButton.titleLabel!.font = UIFont.init(descriptor: UIFontDescriptor(name:"Gill Sans", size:24.0), size: 24.0)
+        let custom = mraidHandler.getExpandProperties()?.useCustomClose
+        if(custom != nil && custom == false){
+            closeButton.setTitleColor(UIColor.white, for:UIControlState.normal)
+            closeButton.setBackgroundImage(UIImage(named:"closeButtonBG", in: Bundle(identifier:"phunware.ios.mraid.sdk"), compatibleWith:nil), for: UIControlState.normal)
+            closeButton.setTitle("X", for:UIControlState.normal)
+            closeButton.titleLabel!.textAlignment = NSTextAlignment.center
+            closeButton.titleLabel!.font = UIFont.init(descriptor: UIFontDescriptor(name:"Gill Sans", size:24.0), size: 24.0)
+        }
         closeButton.addTarget(self, action: action, for:UIControlEvents.touchUpInside)
         
         view.addSubview(closeButton)
@@ -160,8 +162,8 @@ public class PWMRAIDInterstitial : UIViewController, MRAIDDelegate {
         } else {
             NSLayoutConstraint.activate([closeButton.topAnchor.constraint(equalTo: topLayoutGuide.bottomAnchor)])
         }
-//
-//        NSLayoutConstraint.activate([closeButton.topAnchor.constraint(equalTo: view.topAnchor)])
+        //
+        //        NSLayoutConstraint.activate([closeButton.topAnchor.constraint(equalTo: view.topAnchor)])
         NSLayoutConstraint.activate([closeButton.rightAnchor.constraint(equalTo: view.rightAnchor)])
     }
     


### PR DESCRIPTION
Changing parent view controller and resizing the UIKit view were not happening before the mraid creative attempted to resize itself, which sometimes caused the full screen expanded ad to appear tiny.

Just to make sure there's adequate time, I introduced a 25 ms delay before we notify the javascript of the banner ad.  Also some other minor fixes