### PR TITLE
Update for VAST ads, companions, screen orientations, etc.

### DIFF
--- a/Phunware.xcodeproj/project.pbxproj
+++ b/Phunware.xcodeproj/project.pbxproj
@@ -278,6 +278,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = BEBE254A207C1D5E00D7C655;
 			productRefGroup = BEBE2555207C1D5E00D7C655 /* Products */;

--- a/Phunware/MRAID/MRAIDBrowserWindow.swift
+++ b/Phunware/MRAID/MRAIDBrowserWindow.swift
@@ -14,8 +14,8 @@ public class MRAIDBrowserWindow : UIViewController, WKUIDelegate, WKNavigationDe
     private static let btnHeight = CGFloat(50)
     private static let navHeight = btnHeight
     
-    private let navigationRect = CGRect(x:0, y:UIApplication.shared.isStatusBarHidden ? 0 : UIApplication.shared.statusBarFrame.height, width:UIScreen.main.bounds.width, height:navHeight)
-    private let webViewRect = CGRect(x:0, y:navHeight + (UIApplication.shared.isStatusBarHidden ? 0 : UIApplication.shared.statusBarFrame.height), width:UIScreen.main.bounds.width, height:UIScreen.main.bounds.height - navHeight)
+//    private let navigationRect = CGRect(x:0, y:UIApplication.shared.isStatusBarHidden ? 0 : UIApplication.shared.statusBarFrame.height, width:UIScreen.main.bounds.width, height:navHeight)
+//    private let webViewRect = CGRect(x:0, y:navHeight + (UIApplication.shared.isStatusBarHidden ? 0 : UIApplication.shared.statusBarFrame.height), width:UIScreen.main.bounds.width, height:UIScreen.main.bounds.height - navHeight)
     private var webView:WKWebView?
     private var navigationView:UIView?
     
@@ -31,21 +31,29 @@ public class MRAIDBrowserWindow : UIViewController, WKUIDelegate, WKNavigationDe
     private var dividerRect = CGRect(x:0, y:0, width:4.0, height:btnHeight)
     private var onCloseDelegate:()->Void = {}
     
+    
     public func initialize(){
         webView = WKWebView()
         webView!.isOpaque = true
         webView!.isUserInteractionEnabled = true
-        webView!.frame = webViewRect
+        //webView!.frame = webViewRect
         webView!.navigationDelegate = self
         view.backgroundColor = UIColor.white
         view.isUserInteractionEnabled = true
-        navigationView = UIView(frame:navigationRect)
+        navigationView = UIView()
         navigationView!.isOpaque = true
         navigationView!.isUserInteractionEnabled = true
         navigationView!.backgroundColor = UIColor(red: 238.0/255.0, green: 238.0/255.0, blue: 238.0/255.0, alpha: 1)
         view.addSubview(navigationView!)
         view.addSubview(webView!)
+        addFrameConstraints()
         addNavigationButtons()
+    }
+    
+    public override var prefersStatusBarHidden: Bool {
+        get {
+            return false
+        }
     }
     
     public func loadUrl(_ url:String){
@@ -128,6 +136,48 @@ public class MRAIDBrowserWindow : UIViewController, WKUIDelegate, WKNavigationDe
     
     @objc public func onForwardClicked(){
         webView!.goForward()
+    }
+    
+    private func addFrameConstraints(){
+        if #available(iOS 11.0, *) {
+            navigationView?.translatesAutoresizingMaskIntoConstraints = false
+            webView?.translatesAutoresizingMaskIntoConstraints = false
+            view!.addConstraint(NSLayoutConstraint(item:navigationView!, attribute: .top, relatedBy: .equal, toItem: view!.safeAreaLayoutGuide, attribute: .top, multiplier:1.0, constant:0))
+            view!.addConstraint(NSLayoutConstraint(item:navigationView!, attribute: .left, relatedBy: .equal, toItem: view!.safeAreaLayoutGuide, attribute: .left, multiplier:1.0, constant:0))
+            view!.addConstraint(NSLayoutConstraint(item:navigationView!, attribute: .right, relatedBy: .equal, toItem: view!.safeAreaLayoutGuide, attribute: .right, multiplier:1.0, constant:0))
+            NSLayoutConstraint.activate([navigationView!.heightAnchor.constraint(equalToConstant: MRAIDBrowserWindow.navHeight)])
+            
+            view!.addConstraint(NSLayoutConstraint(item:webView!, attribute: .top, relatedBy: .equal, toItem: navigationView!, attribute: .bottom, multiplier:1.0, constant:0))
+            view!.addConstraint(NSLayoutConstraint(item:webView!, attribute: .left, relatedBy: .equal, toItem: view!.safeAreaLayoutGuide, attribute: .left, multiplier:1.0, constant:0))
+            view!.addConstraint(NSLayoutConstraint(item:webView!, attribute: .right, relatedBy: .equal, toItem: view!.safeAreaLayoutGuide, attribute: .right, multiplier:1.0, constant:0))
+            view!.addConstraint(NSLayoutConstraint(item:webView!, attribute: .bottom, relatedBy: .equal, toItem: view!.safeAreaLayoutGuide, attribute: .bottom, multiplier:1.0, constant:0))
+        }else{
+            setOldIOSFrames()
+        }
+    }
+    
+    public override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        if #available(iOS 11.0, *){
+            // constraints shoudl handle it
+        }else{
+            setOldIOSFrames(true)
+        }
+        
+    }
+    
+    private func setOldIOSFrames(_ invert:Bool = false){
+        if(invert){
+            let navigationRect = CGRect(x:0, y:UIApplication.shared.isStatusBarHidden ? 0 : UIApplication.shared.statusBarFrame.height, width:UIScreen.main.bounds.height, height:MRAIDBrowserWindow.navHeight)
+            let webViewRect = CGRect(x:0, y:MRAIDBrowserWindow.navHeight + (UIApplication.shared.isStatusBarHidden ? 0 : UIApplication.shared.statusBarFrame.height), width:UIScreen.main.bounds.height, height:UIScreen.main.bounds.width - MRAIDBrowserWindow.navHeight)
+            navigationView!.frame = navigationRect
+            webView!.frame = webViewRect
+        }else{
+            let navigationRect = CGRect(x:0, y:UIApplication.shared.isStatusBarHidden ? 0 : UIApplication.shared.statusBarFrame.height, width:UIScreen.main.bounds.width, height:MRAIDBrowserWindow.navHeight)
+            let webViewRect = CGRect(x:0, y:MRAIDBrowserWindow.navHeight + (UIApplication.shared.isStatusBarHidden ? 0 : UIApplication.shared.statusBarFrame.height), width:UIScreen.main.bounds.width, height:UIScreen.main.bounds.height - MRAIDBrowserWindow.navHeight)
+            navigationView!.frame = navigationRect
+            webView!.frame = webViewRect
+        }
     }
     
     private func addButtonConstraints(){

--- a/Phunware/Placement+Records.swift
+++ b/Phunware/Placement+Records.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public extension Placement {
     /// Sends request to record impression for this `Placement`.
-    public func recordImpression() {
+    func recordImpression() {
         if let accupixelUrl = self.accupixelUrl.flatMap({ URL(string: $0) }) {
             Phunware.requestPixel(with: accupixelUrl)
         }
@@ -28,7 +28,7 @@ public extension Placement {
     }
     
     /// Sends request to record click for this `Placement`.
-    public func recordClick() {
+    func recordClick() {
         if(!self.clicked){
             self.clicked = true
             if let redirectUrl = self.redirectUrl.flatMap({ URL(string: $0) }) {

--- a/Phunware/Placement.swift
+++ b/Phunware/Placement.swift
@@ -78,12 +78,12 @@ public extension Placement {
         var height: Int!
         
         if(widthObj is Int){
-            width = widthObj as! Int
+            width = (widthObj as! Int)
         }else if (widthObj is String){
             width = Int(widthObj as! String)
         }
         if(heightObj is Int){
-            height = heightObj as! Int
+            height = (heightObj as! Int)
         }else if(heightObj is String){
             height = Int(heightObj as! String)
         }

--- a/Phunware/PlacementRequestConfig.swift
+++ b/Phunware/PlacementRequestConfig.swift
@@ -166,7 +166,7 @@ import AdSupport
 
 public extension PlacementRequestConfig {
     
-    public var queryString: String {
+    var queryString: String {
         var query = ";ID=\(accountId);setID=\(zoneId)"
         if(height != nil && width != nil){query += ";size=\(width as Int?)x\(height as Int?)" }
         

--- a/Phunware/Protocols/PWVASTDelegate.swift
+++ b/Phunware/Protocols/PWVASTDelegate.swift
@@ -39,4 +39,8 @@ public protocol PWVASTDelegate {
     //    func onMinimize()
     //    func onClose()
     //    func onOverlayViewDuration()
+    
+    // non standard
+    func onBrowserOpening()
+    func onBrowserClosing()
 }

--- a/Phunware/VAST/PWVASTCompanion.swift
+++ b/Phunware/VAST/PWVASTCompanion.swift
@@ -9,6 +9,7 @@ import Foundation
 
 class PWVASTCompanion {
     public var staticResource:String?
+    public var htmlResource:String?
     public var trackingEvents:[String : String]?
     public var clickThrough:String?
     public var width:Int? = 0
@@ -18,10 +19,17 @@ class PWVASTCompanion {
         self.staticResource = nil
         self.trackingEvents = nil
         self.clickThrough = nil
+        self.htmlResource = nil
     }
     
     public init(staticResource:String, trackingEvents:[String : String], clickThrough:String){
         self.staticResource = staticResource
+        self.trackingEvents = trackingEvents
+        self.clickThrough = clickThrough
+    }
+    
+    public init(htmlResource:String, trackingEvents:[String: String], clickThrough:String){
+        self.htmlResource = htmlResource
         self.trackingEvents = trackingEvents
         self.clickThrough = clickThrough
     }

--- a/Phunware/VAST/PWVASTParser.swift
+++ b/Phunware/VAST/PWVASTParser.swift
@@ -98,6 +98,8 @@ class PWVASTParser : NSObject, XMLParserDelegate {
                 switch(self.currentElement){
                 case "StaticResource":
                     self.currentCompanion?.staticResource = string
+                case "HTMLResource":
+                    self.currentCompanion?.htmlResource = string
                 case "Tracking":
                     if(currentCompanion?.trackingEvents == nil){
                         currentCompanion?.trackingEvents = [String:String]()

--- a/Phunware/VAST/PWVASTVideo.swift
+++ b/Phunware/VAST/PWVASTVideo.swift
@@ -12,21 +12,26 @@ public class PWVASTVideo : UIViewController, WKUIDelegate {
     private var sources:[Source]?
     private var delegate:PWVASTDelegate?
     private var videoPlayer:PWVideoPlayer!
+    private var orientationMask:UIInterfaceOrientationMask = [.portrait, .landscapeLeft, .landscapeRight]
 
     
-    private let baseurl = "http://ssp-r.phunware.com"
+    private let baseURL = "http://ssp-r.phunware.com"
+    //private let baseurl = "http://servedbyadbutler.com.vm.test"
     
     struct Source {
         public var source:String!
         public var type:String!
     }
     
-    public func initialize(accountID:Int, zoneID:Int, publisherID:Int, delegate:PWVASTDelegate?, poster:String? = ""){
+    public func initialize(accountID:Int, zoneID:Int, publisherID:Int, delegate:PWVASTDelegate?, orientationMask:UIInterfaceOrientationMask? = nil, poster:String? = ""){
         self.zoneID = zoneID
         self.accountID = accountID
         self.publisherID = publisherID
         self.poster = poster
         self.delegate = delegate
+        if(orientationMask != nil){
+            self.orientationMask = orientationMask!
+        }
     }
     
     public func addSource(source:String, type:String){
@@ -42,9 +47,9 @@ public class PWVASTVideo : UIViewController, WKUIDelegate {
             <head>
                 <meta name="viewport" content="initial-scale=1.0" />
                 <link href="http://vjs.zencdn.net/4.12/video-js.css" rel="stylesheet">
-                <script src="http://vjs.zencdn.net/4.12/video.js?v=1"></script>
-                <link href="\(baseurl)/videojs-vast-vpaid/bin/videojs.vast.vpaid.min.css" rel="stylesheet">
-                <script src="http://servedbyadbutler.com.vm.test/videojs-vast-vpaid/bin/videojs_4.vast.vpaid.min.js?v=5"></script>
+                <script src="http://vjs.zencdn.net/4.12/video.js"></script>
+                <link href="\(baseURL)/videojs-vast-vpaid/bin/videojs.vast.vpaid.min.css?v=5" rel="stylesheet">
+                <script src="\(baseURL)/videojs-vast-vpaid/bin/videojs_4.vast.vpaid.min.js?v=5"></script>
             </head>
             <body style="margin:0px; background-color:black">
             <video id="av_video" class="video-js vjs-default-skin" playsinline="true" autoplay="true"
@@ -56,7 +61,7 @@ public class PWVASTVideo : UIViewController, WKUIDelegate {
         str += "data-setup='{ "
         str += "\"plugins\": { "
         str += "\"vastClient\": { "
-        str += "\"adTagUrl\": \"\(baseurl)/vasttemp.spark?setID=\(self.zoneID!)&ID=\(self.accountID!)&pid=\(self.publisherID!)\", "
+        str += "\"adTagUrl\": \"\(baseURL)/vasttemp.spark?setID=\(self.zoneID!)&ID=\(self.accountID!)&pid=\(self.publisherID!)\", "
         str += "\"adCancelTimeout\": 5000, "
         str += "\"adsEnabled\": true "
         str += "} "
@@ -67,7 +72,7 @@ public class PWVASTVideo : UIViewController, WKUIDelegate {
                 str += "<source src=\"\(s.source!)\" type='\(s.type!)'/>"
             }
         }else{
-            str += "<source src=\"\(baseurl)/assets/blank.mp4\" type='video/mp4'/>"
+            str += "<source src=\"\(baseURL)/assets/blank.mp4\" type='video/mp4'/>"
         }
         str += """
         <p class="vjs-no-js">
@@ -84,6 +89,7 @@ public class PWVASTVideo : UIViewController, WKUIDelegate {
     public func play(){
         videoPlayer = PWVideoPlayer()
         videoPlayer.addCloseButtonToVideo = false
+        self.videoPlayer.setOrientationMask(self.orientationMask)
         let body = self.getVideoJSMarkup()
         let previousRootController = UIApplication.shared.delegate?.window??.rootViewController
         MRAIDUtilities.setRootController(videoPlayer)

--- a/SDKTester/SDKTester/Base.lproj/Main.storyboard
+++ b/SDKTester/SDKTester/Base.lproj/Main.storyboard
@@ -60,6 +60,9 @@
                             <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pGv-pT-KpL">
                                 <rect key="frame" x="20" y="241" width="119" height="43"/>
                                 <color key="backgroundColor" white="0.92583626760563376" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="119" id="eDc-7b-Pog"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <inset key="titleEdgeInsets" minX="10" minY="10" maxX="10" maxY="10"/>
                                 <state key="normal" title="Get Banner">
@@ -72,6 +75,9 @@
                             <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oUj-HS-IIX">
                                 <rect key="frame" x="20" y="301" width="133" height="43"/>
                                 <color key="backgroundColor" white="0.92583626760000004" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="133" id="Sl1-hk-ero"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <inset key="titleEdgeInsets" minX="10" minY="10" maxX="10" maxY="10"/>
                                 <state key="normal" title="Get Interstitial"/>
@@ -80,11 +86,14 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pqc-NC-ecJ">
-                                <rect key="frame" x="20" y="362" width="152" height="43"/>
+                                <rect key="frame" x="20" y="362" width="106" height="43"/>
                                 <color key="backgroundColor" white="0.92583626760000004" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="106" id="naZ-dh-rQU"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <inset key="titleEdgeInsets" minX="10" minY="10" maxX="10" maxY="10"/>
-                                <state key="normal" title="Get VAST Video"/>
+                                <state key="normal" title="Get VAST"/>
                                 <connections>
                                     <action selector="onGetVASTVideoClick:" destination="BYZ-38-t0r" eventType="touchUpInside" id="MI7-Ub-55J"/>
                                 </connections>
@@ -178,7 +187,7 @@
                                 <rect key="frame" x="169" y="305" width="61" height="34"/>
                                 <color key="backgroundColor" white="0.92583626760000004" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="61" id="2kI-BP-cg9"/>
+                                    <constraint firstAttribute="width" constant="61" id="LuJ-7X-CeD"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <inset key="titleEdgeInsets" minX="2" minY="2" maxX="2" maxY="2"/>
@@ -187,8 +196,8 @@
                                     <action selector="onDisplayInterstitialClick:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Twk-hd-TY5"/>
                                 </connections>
                             </button>
-                            <button hidden="YES" autoresizesSubviews="NO" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M9R-7H-k7d">
-                                <rect key="frame" x="169" y="244" width="61" height="27"/>
+                            <button hidden="YES" autoresizesSubviews="NO" opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M9R-7H-k7d">
+                                <rect key="frame" x="158" y="246" width="61" height="27"/>
                                 <color key="backgroundColor" white="0.92583626760000004" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="61" id="aUb-sP-p8I"/>
@@ -200,61 +209,70 @@
                                     <action selector="onDismissClick:" destination="BYZ-38-t0r" eventType="touchUpInside" id="3MC-U2-D7k"/>
                                 </connections>
                             </button>
+                            <pickerView contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qmT-do-Z7o">
+                                <rect key="frame" x="133" y="352" width="110" height="65"/>
+                            </pickerView>
+                            <button opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hi0-FG-G4T">
+                                <rect key="frame" x="134" y="368" width="46" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <state key="normal" title="none"/>
+                                <connections>
+                                    <action selector="pickerTouchDown:" destination="BYZ-38-t0r" eventType="touchDown" id="5E1-8i-Vel"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="qmT-do-Z7o" firstAttribute="leading" secondItem="Pqc-NC-ecJ" secondAttribute="trailing" constant="7" id="1Tc-Uw-KE6"/>
                             <constraint firstItem="Z0m-Ni-HkK" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="2kv-MO-bcx"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="1VK-T8-4VE" secondAttribute="trailing" constant="26" id="3cj-dl-zAj"/>
                             <constraint firstItem="Zga-ds-tLO" firstAttribute="top" secondItem="NHK-K5-z0i" secondAttribute="bottom" constant="27" id="5ug-gt-mJm"/>
                             <constraint firstItem="Pqc-NC-ecJ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="6HS-ad-erc"/>
-                            <constraint firstItem="vHm-OT-aX2" firstAttribute="centerY" secondItem="Pqc-NC-ecJ" secondAttribute="centerY" id="6bv-2d-Z45"/>
                             <constraint firstItem="njA-sa-W9D" firstAttribute="leading" secondItem="Yzv-ZV-1lk" secondAttribute="trailing" constant="25" id="7DQ-w5-Rfm"/>
                             <constraint firstItem="bdq-jU-ovJ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="869-UN-Yc8"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="vHm-OT-aX2" secondAttribute="trailing" constant="26" id="AqK-er-nx7"/>
-                            <constraint firstItem="9ol-3o-PfR" firstAttribute="centerY" secondItem="oUj-HS-IIX" secondAttribute="centerY" id="B4a-tg-Vv7"/>
                             <constraint firstItem="Yzv-ZV-1lk" firstAttribute="leading" secondItem="5bD-JF-NjJ" secondAttribute="trailing" constant="25" id="DDb-WQ-gwd"/>
                             <constraint firstItem="wAs-qz-Y6C" firstAttribute="leading" secondItem="UPL-SP-Gdz" secondAttribute="trailing" constant="25" id="DNx-ci-hTd"/>
                             <constraint firstItem="Hwq-yt-kSM" firstAttribute="leading" secondItem="EBC-MD-jjB" secondAttribute="trailing" constant="19" id="FaU-E6-zU2"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Z0m-Ni-HkK" secondAttribute="trailing" constant="275" id="GIS-eM-SPM"/>
-                            <constraint firstItem="wAs-qz-Y6C" firstAttribute="centerY" secondItem="Pqc-NC-ecJ" secondAttribute="centerY" id="Iht-O9-JpC"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="oUj-HS-IIX" secondAttribute="trailing" constant="261" id="JGN-I2-zjO"/>
-                            <constraint firstItem="5bD-JF-NjJ" firstAttribute="centerY" secondItem="pGv-pT-KpL" secondAttribute="centerY" id="KFi-b2-8v7"/>
-                            <constraint firstItem="UPL-SP-Gdz" firstAttribute="centerY" secondItem="Pqc-NC-ecJ" secondAttribute="centerY" id="KSg-5v-4RK"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="pGv-pT-KpL" secondAttribute="trailing" constant="275" id="Kb2-Nt-D4R"/>
-                            <constraint firstItem="jGi-37-QAe" firstAttribute="centerY" secondItem="oUj-HS-IIX" secondAttribute="centerY" id="LcD-td-Cdn"/>
+                            <constraint firstItem="UPL-SP-Gdz" firstAttribute="centerY" secondItem="Pqc-NC-ecJ" secondAttribute="centerY" id="GHS-gH-Xxa"/>
+                            <constraint firstItem="vHm-OT-aX2" firstAttribute="centerY" secondItem="Pqc-NC-ecJ" secondAttribute="centerY" id="IzZ-T1-Ye3"/>
+                            <constraint firstItem="M9R-7H-k7d" firstAttribute="leading" secondItem="pGv-pT-KpL" secondAttribute="trailing" constant="19" id="LNB-wl-iQX"/>
                             <constraint firstItem="Z0m-Ni-HkK" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="26" id="POg-0v-jAL"/>
+                            <constraint firstItem="hi0-FG-G4T" firstAttribute="leading" secondItem="Pqc-NC-ecJ" secondAttribute="trailing" constant="8" id="PZt-ZZ-B1G"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="njA-sa-W9D" secondAttribute="trailing" constant="26" id="Slg-54-mzI"/>
-                            <constraint firstItem="njA-sa-W9D" firstAttribute="centerY" secondItem="pGv-pT-KpL" secondAttribute="centerY" id="SpR-LD-6BZ"/>
-                            <constraint firstItem="M9R-7H-k7d" firstAttribute="centerY" secondItem="pGv-pT-KpL" secondAttribute="centerY" id="TMI-Kx-gTS"/>
                             <constraint firstItem="tQJ-33-kwU" firstAttribute="leading" secondItem="Hwq-yt-kSM" secondAttribute="trailing" constant="19" id="VWV-Vf-sns"/>
                             <constraint firstItem="EBC-MD-jjB" firstAttribute="top" secondItem="bdq-jU-ovJ" secondAttribute="bottom" constant="22" id="VbU-AL-Kqp"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="bdq-jU-ovJ" secondAttribute="trailing" constant="275" id="W5b-za-MYZ"/>
+                            <constraint firstItem="jGi-37-QAe" firstAttribute="centerY" secondItem="oUj-HS-IIX" secondAttribute="centerY" id="Vlf-8h-k3K"/>
                             <constraint firstItem="NHK-K5-z0i" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="31" id="WlH-Jj-cuw"/>
                             <constraint firstItem="EBC-MD-jjB" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="YLa-oY-Qjg"/>
                             <constraint firstItem="R8B-w5-EIs" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="a54-p1-I2Z"/>
                             <constraint firstItem="tQJ-33-kwU" firstAttribute="centerY" secondItem="Hwq-yt-kSM" secondAttribute="centerY" id="aEZ-3n-0Fj"/>
+                            <constraint firstItem="9ol-3o-PfR" firstAttribute="centerY" secondItem="oUj-HS-IIX" secondAttribute="centerY" id="ahJ-eM-rsf"/>
+                            <constraint firstItem="5bD-JF-NjJ" firstAttribute="centerY" secondItem="pGv-pT-KpL" secondAttribute="centerY" id="avy-bR-cmE"/>
                             <constraint firstItem="Zga-ds-tLO" firstAttribute="leading" secondItem="bdq-jU-ovJ" secondAttribute="trailing" constant="19" id="cl1-ec-JCG"/>
                             <constraint firstItem="vHm-OT-aX2" firstAttribute="leading" secondItem="wAs-qz-Y6C" secondAttribute="trailing" constant="25" id="dNB-zZ-RLd"/>
                             <constraint firstItem="pGv-pT-KpL" firstAttribute="top" secondItem="EBC-MD-jjB" secondAttribute="bottom" constant="39" id="dXo-WR-Wme"/>
                             <constraint firstItem="1VK-T8-4VE" firstAttribute="leading" secondItem="9ol-3o-PfR" secondAttribute="trailing" constant="25" id="eHW-2y-hqx"/>
                             <constraint firstItem="oUj-HS-IIX" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="gEY-GM-wc3"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Pqc-NC-ecJ" secondAttribute="trailing" constant="242" id="lG5-d8-rQO"/>
+                            <constraint firstItem="Yzv-ZV-1lk" firstAttribute="centerY" secondItem="pGv-pT-KpL" secondAttribute="centerY" id="gVQ-AV-Plz"/>
+                            <constraint firstItem="M9R-7H-k7d" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" id="hAG-nY-2Hz"/>
+                            <constraint firstItem="qUx-JV-9Gv" firstAttribute="centerY" secondItem="oUj-HS-IIX" secondAttribute="centerY" id="hIa-Lp-TfE"/>
+                            <constraint firstItem="njA-sa-W9D" firstAttribute="centerY" secondItem="pGv-pT-KpL" secondAttribute="centerY" id="jrR-AW-rzs"/>
+                            <constraint firstItem="hi0-FG-G4T" firstAttribute="centerY" secondItem="Pqc-NC-ecJ" secondAttribute="centerY" id="kUE-me-OsG"/>
                             <constraint firstItem="pGv-pT-KpL" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="lYQ-vd-Vht"/>
                             <constraint firstItem="R8B-w5-EIs" firstAttribute="top" secondItem="Pqc-NC-ecJ" secondAttribute="bottom" constant="29" id="lre-cR-6Ep"/>
-                            <constraint firstItem="Yzv-ZV-1lk" firstAttribute="centerY" secondItem="pGv-pT-KpL" secondAttribute="centerY" id="oKU-aq-AS2"/>
+                            <constraint firstItem="qUx-JV-9Gv" firstAttribute="leading" secondItem="oUj-HS-IIX" secondAttribute="trailing" constant="16" id="mpr-8N-gGr"/>
+                            <constraint firstItem="qmT-do-Z7o" firstAttribute="centerY" secondItem="Pqc-NC-ecJ" secondAttribute="centerY" id="n1d-1N-kew"/>
+                            <constraint firstItem="wAs-qz-Y6C" firstAttribute="centerY" secondItem="Pqc-NC-ecJ" secondAttribute="centerY" id="oLI-tg-EXc"/>
                             <constraint firstItem="Hwq-yt-kSM" firstAttribute="top" secondItem="Zga-ds-tLO" secondAttribute="bottom" constant="31" id="oTC-gm-ZAa"/>
                             <constraint firstItem="Pqc-NC-ecJ" firstAttribute="top" secondItem="oUj-HS-IIX" secondAttribute="bottom" constant="18" id="och-nB-ls4"/>
                             <constraint firstItem="9ol-3o-PfR" firstAttribute="leading" secondItem="jGi-37-QAe" secondAttribute="trailing" constant="25" id="rNa-PJ-tdc"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="R8B-w5-EIs" secondAttribute="trailing" constant="20" id="rXK-RN-JEc"/>
                             <constraint firstItem="bdq-jU-ovJ" firstAttribute="top" secondItem="Z0m-Ni-HkK" secondAttribute="bottom" constant="20" id="sLJ-oj-VcC"/>
-                            <constraint firstItem="M9R-7H-k7d" firstAttribute="centerX" secondItem="qUx-JV-9Gv" secondAttribute="centerX" id="sV3-Up-pY5"/>
                             <constraint firstItem="oUj-HS-IIX" firstAttribute="top" secondItem="pGv-pT-KpL" secondAttribute="bottom" constant="17" id="tow-kc-hhd"/>
-                            <constraint firstItem="qUx-JV-9Gv" firstAttribute="leading" secondItem="oUj-HS-IIX" secondAttribute="trailing" constant="16" id="uG5-8a-Kxt"/>
-                            <constraint firstItem="qUx-JV-9Gv" firstAttribute="centerY" secondItem="oUj-HS-IIX" secondAttribute="centerY" id="uI6-2B-oio"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="EBC-MD-jjB" secondAttribute="trailing" constant="275" id="x2z-tI-biO"/>
                             <constraint firstItem="NHK-K5-z0i" firstAttribute="leading" secondItem="Z0m-Ni-HkK" secondAttribute="trailing" constant="19" id="xJQ-Wg-QNT"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="R8B-w5-EIs" secondAttribute="bottom" constant="13" id="xXP-Xc-5Sn"/>
-                            <constraint firstItem="1VK-T8-4VE" firstAttribute="centerY" secondItem="oUj-HS-IIX" secondAttribute="centerY" id="yxm-Sa-UYJ"/>
+                            <constraint firstItem="1VK-T8-4VE" firstAttribute="centerY" secondItem="oUj-HS-IIX" secondAttribute="centerY" id="zrN-bT-3se"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
@@ -273,6 +291,8 @@
                         <outlet property="btnTopCenter" destination="Yzv-ZV-1lk" id="kK6-fg-ZYP"/>
                         <outlet property="btnTopLeft" destination="5bD-JF-NjJ" id="zAa-9Y-MG2"/>
                         <outlet property="btnTopRight" destination="njA-sa-W9D" id="EoI-So-eWX"/>
+                        <outlet property="lblPicker" destination="hi0-FG-G4T" id="NjL-Je-fGe"/>
+                        <outlet property="pickerOrientation" destination="qmT-do-Z7o" id="qoK-fj-y4L"/>
                         <outlet property="txtAccountID" destination="Z0m-Ni-HkK" id="eIb-NH-coq"/>
                         <outlet property="txtLog" destination="R8B-w5-EIs" id="nhO-Ti-tEZ"/>
                         <outlet property="txtPublisherID" destination="EBC-MD-jjB" id="oIB-A2-8u5"/>

--- a/SDKTester/SDKTester/SDKConsumer.swift
+++ b/SDKTester/SDKTester/SDKConsumer.swift
@@ -99,13 +99,13 @@ class SDKConsumer : NSObject {
         }
     }
     
-    func getVASTVideo(accountID:Int, zoneID:Int, publisherID:Int){
+    func getVASTVideo(accountID:Int, zoneID:Int, publisherID:Int, orientationMask:UIInterfaceOrientationMask? = nil){
         if(self.VASTDelegate == nil){
             self.log("No VAST Delegate was assigned")
             return
         }
         let vast = PWVASTVideo()
-        vast.initialize(accountID: accountID, zoneID:zoneID, publisherID:publisherID, delegate:self.VASTDelegate)
+        vast.initialize(accountID: accountID, zoneID:zoneID, publisherID:publisherID, delegate:self.VASTDelegate, orientationMask:orientationMask)
         vast.play()
     }
 }

--- a/SDKTester/SDKTester/ViewController.swift
+++ b/SDKTester/SDKTester/ViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Phunware
 
-class ViewController: UIViewController , UITextFieldDelegate, PWInterstitialDelegate, PWVASTDelegate {
+class ViewController: UIViewController , UITextFieldDelegate, PWInterstitialDelegate, PWVASTDelegate, UIPickerViewDelegate, UIPickerViewDataSource {
 
     @IBOutlet weak var btnGetBanner: UIButton!
     @IBOutlet weak var btnGetInterstitial: UIButton!
@@ -34,6 +34,14 @@ class ViewController: UIViewController , UITextFieldDelegate, PWInterstitialDele
     @IBOutlet weak var btnDisplayInterstitial: UIButton!
     @IBOutlet weak var btnDismiss: UIButton!
     
+    @IBOutlet weak var viewOrientation: UIView!
+    
+    @IBOutlet weak var pickerOrientation: UIPickerView!
+    
+    
+    @IBOutlet weak var lblPicker: UIButton!
+    let pickerData:[String] = ["none", "portrait", "landscape"]
+    
     var accountID:Int!
     var zoneID:Int!
     var publisherID:Int!
@@ -52,12 +60,10 @@ class ViewController: UIViewController , UITextFieldDelegate, PWInterstitialDele
             self.log(str)
         }
         sdk.setLoggingFunction(log)
-        
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
         txtAccountID.delegate = self
         txtZoneID.delegate = self
         txtPublisherID.delegate = self
@@ -65,13 +71,62 @@ class ViewController: UIViewController , UITextFieldDelegate, PWInterstitialDele
         selectPosition(btnBottomCenter)
         sdk.setInterstitialDelegate(self)
         sdk.setVASTDelegate(self)
+        pickerOrientation.delegate = self
+        pickerOrientation.dataSource = self
+        pickerOrientation.isHidden = true
+        lblPicker.isUserInteractionEnabled = true
+        
     }
 
+    @IBAction func pickerTouchDown(_ sender: Any) {
+        lblPicker.isHidden = true
+        pickerOrientation.isHidden = false
+    }
+    
     func textFieldShouldReturn(_ textField: UITextField) -> Bool{
         textField.resignFirstResponder()
         return true
     }
     
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+    // Number of columns of data
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    // Capture the picker view selection
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        // This method is triggered whenever the user makes a change to the picker selection.
+        // The parameter named row and component represents what was selected.
+        lblPicker.setTitle(pickerData[row], for:UIControl.State.normal)
+        lblPicker.isHidden = false
+        pickerOrientation.isHidden = true
+    }
+    
+    // The number of rows of data
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        return pickerData.count
+    }
+    
+    // The data to return fopr the row and component (column) that's being passed in
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        return pickerData[row]
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+        var label = UILabel()
+        if let v = view {
+            label = v as! UILabel
+        }
+        label.font = UIFont (name: "Helvetica Neue", size: 10)
+        label.text =  pickerData[row]
+        label.textAlignment = .left
+        return label
+    }
     
     @IBAction func onPositionClicked(_ sender: UIButton) {
         selectPosition(sender)
@@ -121,7 +176,11 @@ class ViewController: UIViewController , UITextFieldDelegate, PWInterstitialDele
         if(!validateInputs(includePublisher:true)){
             return
         }
-        sdk.getVASTVideo(accountID: self.accountID, zoneID: self.zoneID, publisherID: self.publisherID)
+        var orientationMask:UIInterfaceOrientationMask? = nil
+        if(lblPicker.currentTitle! == "portrait") {orientationMask = [ .portrait ]}
+        if(lblPicker.currentTitle! == "landscape") {orientationMask = [ .landscapeLeft ]}
+        
+        sdk.getVASTVideo(accountID: self.accountID, zoneID: self.zoneID, publisherID: self.publisherID, orientationMask:orientationMask)
     }
     
     @IBAction func onDisplayInterstitialClick(_ sender: Any) {
@@ -294,6 +353,13 @@ class ViewController: UIViewController , UITextFieldDelegate, PWInterstitialDele
         log("VAST :: closeLinear")
     }
     
+    func onBrowserOpening(){
+        log("VAST :: onBrowserOpening")
+    }
+    
+    func onBrowserClosing(){
+        log("VAST :: onBrowserClosing")
+    }
 }
 
 


### PR DESCRIPTION
Added events for opening a browser, and returning from the browser in VAST ads
Added ability to lock VAST ads to a given orientation
Close button / Browser window should respect iPhone X odd status bar
Removed play button from VAST pre-loading
Companion ads (end cards) can now have HTML content